### PR TITLE
DebuggerDisplay annotations and misc

### DIFF
--- a/Packages/ca.tekly.common/Runtime/Terminal/TerminalInputField.cs
+++ b/Packages/ca.tekly.common/Runtime/Terminal/TerminalInputField.cs
@@ -18,8 +18,9 @@ namespace Tekly.Common.Terminal
 
         public override void OnUpdateSelected(BaseEventData eventData)
         {
-            if (!isFocused)
+            if (!isFocused) {
                 return;
+            }
 
             var consumedEvent = false;
             while (Event.PopEvent(m_processingEvent)) {
@@ -37,8 +38,9 @@ namespace Tekly.Common.Terminal
 
                     var shouldContinue = KeyPressed(m_processingEvent);
                     if (shouldContinue == EditState.Finish) {
-                        if (!wasCanceled)
+                        if (!wasCanceled) {
                             SendOnSubmit();
+                        }
 
                         DeactivateInputField();
                         break;
@@ -59,8 +61,9 @@ namespace Tekly.Common.Terminal
                 }
             }
 
-            if (consumedEvent)
+            if (consumedEvent) {
                 UpdateLabel();
+            }
 
             eventData.Use();
         }
@@ -102,8 +105,10 @@ namespace Tekly.Common.Terminal
                 
                 if (index != -1) {
                     var endIndex = input.Substring(index, input.Length - index).IndexOf('>');
-                    if (endIndex > 0)
+                    if (endIndex > 0) {
                         input = input.Remove(index, endIndex + 1);
+                    }
+
                     continue;
                 }
 

--- a/Packages/ca.tekly.datamodels/Runtime/Models/BasicValueModel.cs
+++ b/Packages/ca.tekly.datamodels/Runtime/Models/BasicValueModel.cs
@@ -38,7 +38,15 @@ namespace Tekly.DataModels.Models
 
         public override string ToDisplayString()
         {
-            return Value == 0 ? "0" : Value.ToString("##,#.##");
+            if (Value == 0) {
+                return "0";
+            }
+
+            if (Value < 1_000_000_000) {
+                return Value.ToString("##,#.##");
+            }
+
+            return Value.ToString("e2");
         }
     }
 

--- a/Packages/ca.tekly.datamodels/Runtime/Models/ModelKey.cs
+++ b/Packages/ca.tekly.datamodels/Runtime/Models/ModelKey.cs
@@ -4,9 +4,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Tekly.DataModels.Models
 {
+    [DebuggerDisplay("Keys=[{DebuggerDisplayKeys}] IsRelative=[{IsRelative}]")]
     public class ModelKey
     {
         public readonly string[] Keys;
@@ -17,13 +19,13 @@ namespace Tekly.DataModels.Models
             Keys = keys;
             IsRelative = isRelative;
         }
-        
+
         public static ModelKey Parse(string key)
         {
             if (string.IsNullOrEmpty(key)) {
                 return null;
             }
-            
+
             if (s_cache.TryGetValue(key, out var modelKey)) {
                 return modelKey;
             }
@@ -42,7 +44,7 @@ namespace Tekly.DataModels.Models
             if (isRelative) {
                 var oldKeys = keys;
                 keys = new string[keys.Length - 1];
-                
+
                 Array.Copy(oldKeys, 1, keys, 0, keys.Length);
             }
 
@@ -58,6 +60,7 @@ namespace Tekly.DataModels.Models
             return key.Substring(2);
         }
 
+        private string DebuggerDisplayKeys => string.Join(".", Keys);
         private static readonly Dictionary<string, ModelKey> s_cache = new Dictionary<string, ModelKey>();
     }
 }

--- a/Packages/ca.tekly.datamodels/Runtime/Models/ObjectModel.cs
+++ b/Packages/ca.tekly.datamodels/Runtime/Models/ObjectModel.cs
@@ -3,6 +3,7 @@
 // ============================================================================
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using Tekly.Common.Observables;
 
@@ -14,6 +15,7 @@ namespace Tekly.DataModels.Models
         Shared
     }
     
+    [DebuggerDisplay("Key=[{Key}] ReferenceType=[{ReferenceType}]")]
     public struct ModelReference
     {
         public readonly IModel Model;

--- a/Packages/ca.tekly.logger/Runtime/StackTraceUtilities.cs
+++ b/Packages/ca.tekly.logger/Runtime/StackTraceUtilities.cs
@@ -90,12 +90,14 @@ namespace Tekly.Logging
                 StackFrame frame = stackTrace.GetFrame(iIndex);
 
                 MethodBase mb = frame.GetMethod();
-                if (mb == null)
+                if (mb == null) {
                     continue;
+                }
 
                 Type classType = mb.DeclaringType;
-                if (classType == null)
+                if (classType == null) {
                     continue;
+                }
 
                 var classTypeName = classType.Name;
                 var classTypeNamespace = classType.Namespace;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "1.19.18",
-    "com.unity.ide.rider": "3.0.12",
+    "com.unity.ide.rider": "3.0.14",
     "com.unity.mobile.android-logcat": "1.2.3",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -139,7 +139,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.12",
+      "version": "3.0.14",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
This pull request adds `DebuggerDisplay` annotations to a few classes to make debugging a bit easier.  It also applies some small code formatting tweaks, and uses scientific notation in NumberValueModel.ToDisplayString() when the value is large.