### PR TITLE
Adding links to stacktraces in Unity logs

### DIFF
--- a/Packages/ca.tekly.logger/Runtime/LogDestinations/UnityLogDestination.cs
+++ b/Packages/ca.tekly.logger/Runtime/LogDestinations/UnityLogDestination.cs
@@ -28,7 +28,7 @@ namespace Tekly.Logging.LogDestinations
         private readonly ThreadLocal<StringBuilder> m_stringBuilders = new ThreadLocal<StringBuilder>(() => new StringBuilder(512));
 
 #if UNITY_EDITOR
-        private Regex linkRegex = new Regex("(.* \\(at )(([^\\/].*):([0-9]+))", RegexOptions.RightToLeft);
+        private Regex m_linkRegex = new Regex("(.* \\(at )(([^\\/].*):([0-9]+))", RegexOptions.RightToLeft);
 #endif
 
         public UnityLogDestination(LogDestinationConfig config)
@@ -104,7 +104,7 @@ namespace Tekly.Logging.LogDestinations
             var rows = stackTrace.Split('\n');
 
             foreach (var row in rows) {
-                var match = linkRegex.Match(row);
+                var match = m_linkRegex.Match(row);
 
                 if (!match.Success) {
                     sb.Append(row).Append("\n");

--- a/Packages/ca.tekly.logger/Runtime/LogDestinations/UnityLogDestination.cs
+++ b/Packages/ca.tekly.logger/Runtime/LogDestinations/UnityLogDestination.cs
@@ -27,6 +27,10 @@ namespace Tekly.Logging.LogDestinations
 
         private readonly ThreadLocal<StringBuilder> m_stringBuilders = new ThreadLocal<StringBuilder>(() => new StringBuilder(512));
 
+#if UNITY_EDITOR
+        private Regex linkRegex = new Regex("(.* \\(at )(([^\\/].*):([0-9]+))", RegexOptions.RightToLeft);
+#endif
+
         public UnityLogDestination(LogDestinationConfig config)
         {
             Name = config.Name;
@@ -100,7 +104,7 @@ namespace Tekly.Logging.LogDestinations
             var rows = stackTrace.Split('\n');
 
             foreach (var row in rows) {
-                var match = Regex.Match(row, "(.* \\(at )(([^\\/].*):([0-9]+))", RegexOptions.RightToLeft);
+                var match = linkRegex.Match(row);
 
                 if (!match.Success) {
                     sb.Append(row).Append("\n");

--- a/Packages/ca.tekly.logger/Runtime/StackTraceUtilities.cs
+++ b/Packages/ca.tekly.logger/Runtime/StackTraceUtilities.cs
@@ -70,13 +70,11 @@ namespace Tekly.Logging
             }
 
             sb.Append(traceString + "\n");
-            sb.Replace("\\", "/");
+            sb.Replace('\\', '/');
             sb.Replace(s_projectFolder, "");
 
             StackTrace trace = new StackTrace(2, true);
             ExtractFormattedStackTrace(trace, sb);
-
-            sb.Replace("\\", "/");
             stackTrace = sb.ToString();
         }
 
@@ -157,7 +155,7 @@ namespace Tekly.Logging
                 sb.Append("\n");
             }
 
-            sb.Replace("\\", "/");
+            sb.Replace('\\', '/');
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Packages/ca.tekly.logger/Runtime/TkLogger.Static.cs
+++ b/Packages/ca.tekly.logger/Runtime/TkLogger.Static.cs
@@ -221,7 +221,6 @@ namespace Tekly.Logging
 
             var level = UnityLogDestination.TypeToLevel(type);
             var loggerName = LoggerConstants.UNITY_LOG_NAME;
-            stacktrace = stacktrace.Replace("\\", "/");
             
             LogToDestinations(DefaultGroup, new TkLogMessage(level, loggerName, loggerName, message, stacktrace), LogSource.Unity);
         }
@@ -246,8 +245,6 @@ namespace Tekly.Logging
             sb.Clear();
 
             StackTraceUtilities.ExtractStackTrace(sb, 4);
-
-            sb.Replace("\\", "/");
 
             return sb.ToString();
         }

--- a/tekly-packages.sln.DotSettings
+++ b/tekly-packages.sln.DotSettings
@@ -1,6 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeThisQualifier/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceIfStatementBraces/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue"></s:String>
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexRemoved">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_IFELSE/@EntryValue">Required</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">None</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ACCESSOR_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>


### PR DESCRIPTION
This pull request adds links to the stacktrace lines in the Unity editor, allowing Unity to open the editor the code line related to that stack trace.