### PR TITLE
Double-clicking a log entry in the console opens the editor

### DIFF
--- a/Packages/ca.tekly.logger/Editor.meta
+++ b/Packages/ca.tekly.logger/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ba5729fd73afde4c93e8aa435998744
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/ca.tekly.logger/Editor/Tekly.Logger.Editor.asmdef
+++ b/Packages/ca.tekly.logger/Editor/Tekly.Logger.Editor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Unity.InternalAPIEngineBridgeDev.002",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/ca.tekly.logger/Editor/Tekly.Logger.Editor.asmdef.meta
+++ b/Packages/ca.tekly.logger/Editor/Tekly.Logger.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 94e3b15ed3beceb40ae95b6b783e0cf3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/ca.tekly.logger/Editor/UnityLogDestinationEditorBridge.cs
+++ b/Packages/ca.tekly.logger/Editor/UnityLogDestinationEditorBridge.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEngine;
+
+namespace Tekly.Logging.LogDestinations
+{
+    public static class UnityLogDestinationEditorBridge
+    {
+        public static void Log(LogType logType, string message)
+        {
+            var logEntry = ParseMessage(message);
+
+            switch (logType) {
+                case LogType.Log:
+                    LogInfo(logEntry);
+                    break;
+                case LogType.Warning:
+                    LogWarning(logEntry);
+                    break;
+                default:
+                    LogError(logEntry);
+                    break;
+            }
+        }
+
+        private static LogEntry ParseMessage(string message)
+        {
+            var match = Regex.Match(message, "<a href=\"(.*)\" line=\"([0-9]+)");
+
+            var output = new LogEntry {
+                message = message
+            };
+
+            if (match != Match.Empty && match.Groups.Count > 2) {
+                output.file = match.Groups[1].Captures[0].Value;
+                output.line = Convert.ToInt32(match.Groups[2].Captures[0].Value);
+            }
+
+            return output;
+        }
+
+        private static void LogInfo(LogEntry logEntry)
+        {
+            Debug.LogInfo(logEntry.message, logEntry.file, logEntry.line, logEntry.column);
+        }
+
+        private static void LogWarning(LogEntry logEntry)
+        {
+            Debug.LogWarning(logEntry.message, logEntry.file, logEntry.line, logEntry.column);
+        }
+
+        private static void LogError(LogEntry logEntry)
+        {
+            Debug.LogError(logEntry.message, logEntry.file, logEntry.line, logEntry.column);
+        }
+    }
+}

--- a/Packages/ca.tekly.logger/Editor/UnityLogDestinationEditorBridge.cs.meta
+++ b/Packages/ca.tekly.logger/Editor/UnityLogDestinationEditorBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b71e7b04e3b00742845f49afc116863
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/ca.tekly.logger/Runtime/LogDestinations/UnityLogDestination.cs
+++ b/Packages/ca.tekly.logger/Runtime/LogDestinations/UnityLogDestination.cs
@@ -85,11 +85,19 @@ namespace Tekly.Logging.LogDestinations
 
             try {
                 var logType = LevelToType(message.Level);
+#if UNITY_EDITOR
+                if (context == null) {
+                    UnityLogDestinationEditorBridge.Log(logType, sb.ToString());
+                } else {
+                    Debug.LogFormat(logType, LogOption.NoStacktrace, context, sb.ToString());
+                }
+#else
                 Debug.LogFormat(logType, LogOption.NoStacktrace, context, sb.ToString());
+#endif
+                    
             } catch (Exception ex) {
-                Debug.LogError(
-                    "Exception while trying to log a message. Likely one of its params is not set. Message:\n\n" + sb);
-                Debug.LogException(ex);
+                Debug.LogError("Exception while trying to log a message. Likely one of its params is not set. Message:\n\n" + sb, context);
+                Debug.LogException(ex, context);
             }
         }
 

--- a/Packages/ca.tekly.logger/Runtime/Tekly.Logger.asmdef
+++ b/Packages/ca.tekly.logger/Runtime/Tekly.Logger.asmdef
@@ -2,7 +2,8 @@
     "name": "Tekly.Logger",
     "rootNamespace": "Tekly.Logging",
     "references": [
-        "GUID:b9160372c6c55a741932d482673e3abb"
+        "GUID:b9160372c6c55a741932d482673e3abb",
+        "GUID:94e3b15ed3beceb40ae95b6b783e0cf3"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
This pull request uses internal Unity methods when logging messages in the editor to give expected functionality when double-clicking on a line in the Unity console.  These internal methods do not have an overload for context so if context is sent with the log then the previous flow is used (and double-clicking doesn't work)