### PR TITLE
Chance() call no longer always return true

### DIFF
--- a/Packages/ca.tekly.common/Runtime/Utils/NumberGenerator.cs
+++ b/Packages/ca.tekly.common/Runtime/Utils/NumberGenerator.cs
@@ -12,19 +12,19 @@ namespace Tekly.Common.Utils
 
         public uint Seed => m_seed;
         public uint Sequence => m_sequence;
-        
+
         public NumberGenerator()
         {
             m_seed = GenerateUnitySeed();
             m_sequence = 0;
         }
-        
+
         public NumberGenerator(uint seed, uint sequence = default)
         {
             m_seed = seed;
             m_sequence = sequence;
         }
-        
+
         public NumberGenerator(NumberGeneratorState state)
         {
             m_seed = state.Seed;
@@ -35,18 +35,18 @@ namespace Tekly.Common.Utils
         {
             ReSeed(GenerateUnitySeed());
         }
-        
+
         public void ReSeed(uint seed, uint sequence = default)
         {
             m_seed = seed;
             m_sequence = sequence;
         }
-        
+
         public void ReSeed(NumberGeneratorState state)
         {
             ReSeed(state.Seed, state.Sequence);
         }
-        
+
         public int Range(int minInclusive, int maxExclusive)
         {
             return XXHash.Int(m_seed, m_sequence++, minInclusive, maxExclusive);
@@ -63,7 +63,7 @@ namespace Tekly.Common.Utils
         /// <param name="likelyHood">Between 0 and 1</param>
         public bool Chance(float likelyHood)
         {
-            return Range(0, 1) <= likelyHood;
+            return Range(0f, 1f) <= likelyHood;
         }
 
         public NumberGeneratorState ToState()
@@ -78,7 +78,7 @@ namespace Tekly.Common.Utils
         {
             return (uint) UnityEngine.Random.Range(0, int.MaxValue - 1);
         }
-        
+
         public static NumberGenerator FromUnity()
         {
             return new NumberGenerator(GenerateUnitySeed());


### PR DESCRIPTION
This pull request chances Chance() to call `Range(0f, 1f)` instead of `Range(0, 1)`. The previous behavior always returned `true`