### PR TITLE
Fixes for editor startup errors with various Webster states

### DIFF
--- a/Assets/Scripts/App/AppCore.cs
+++ b/Assets/Scripts/App/AppCore.cs
@@ -8,7 +8,6 @@ using Tekly.Glass;
 using Tekly.Injectors;
 using Tekly.Logging;
 using Tekly.TreeState;
-using Tekly.TreeState.StandardActivities;
 using Tekly.Webster;
 using UnityEngine;
 
@@ -23,7 +22,7 @@ namespace TeklySample.App
         {
             ITimeProvider localTimeProvider = new LocalTimeProvider();
             m_localTimeProviderRef.Initialize(localTimeProvider);
-            
+
             var balanceManager = new BalanceManager(ContentProvider.Instance);
 
             container.Register(this);
@@ -32,9 +31,9 @@ namespace TeklySample.App
             container.Register(balanceManager);
             container.Register(RootModel.Instance);
             container.Register(localTimeProvider);
-            
+
             container.Register(m_glass);
-            
+
             RootModel.Instance.Add("app", new AppModel(balanceManager));
 
             Debug.Log("Crash Detected: " + CrashCanary.Instance.CrashDetected);
@@ -49,19 +48,19 @@ namespace TeklySample.App
 
             ModelManager.Instance.Tick();
         }
-        
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Initialize()
         {
             TkLogger.Initialize();
         }
-        
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void InitializeDebug()
         {
             WebsterServer.Start(true);
             WebsterServer.AddRouteHandler<SampleWebsterHandler>();
-            
+
             TreeStateRegistry.Instance.ActivityModeChanged.Subscribe(evt => {
                 var type = evt.IsState ? "Tree State" : "Tree Activity";
                 switch (evt.Mode) {

--- a/Packages/ca.tekly.webster/Webster/Frameline.cs
+++ b/Packages/ca.tekly.webster/Webster/Frameline.cs
@@ -1,4 +1,4 @@
-﻿//=============================================================================	
+﻿//=============================================================================
 // Copyright Matthew King. All rights reserved.
 //=============================================================================
 
@@ -6,7 +6,6 @@
 #define FRAMELINE_ENABLE
 #endif
 
-using System;
 using Tekly.Webster.FramelineCore;
 
 namespace Tekly.Webster
@@ -22,7 +21,7 @@ namespace Tekly.Webster
 #endif
 		public static void InstantEvent(string id, string type)
 		{
-			Instance.InstantEvent(id, type);
+			Instance?.InstantEvent(id, type);
 		}
 
 #if !FRAMELINE_ENABLE
@@ -30,13 +29,13 @@ namespace Tekly.Webster
 #endif
 		public static void BeginEvent(string id, string type)
 		{
-			Instance.BeginEventGetId(id, type);
+			Instance?.BeginEventGetId(id, type);
 		}
 
 		public static int BeginEventGetId(string id, string type)
 		{
 #if FRAMELINE_ENABLE
-			return Instance.BeginEventGetId(id, type);
+			return Instance?.BeginEventGetId(id, type) ?? -1;
 #else
             return -1;
 #endif
@@ -44,7 +43,7 @@ namespace Tekly.Webster
 
 		public static FramelineEventDisposable BeginEventDisposable(string id, string type)
 		{
-			return Instance.BeginEventDisposable(id, type);
+			return Instance?.BeginEventDisposable(id, type) ?? FramelineEventDisposable.Unit;
 		}
 
 #if !FRAMELINE_ENABLE
@@ -52,7 +51,7 @@ namespace Tekly.Webster
 #endif
 		public static void EndEvent(int frameEventId)
 		{
-			Instance.EndEvent(frameEventId);
+			Instance?.EndEvent(frameEventId);
 		}
 
 #if !FRAMELINE_ENABLE
@@ -60,7 +59,7 @@ namespace Tekly.Webster
 #endif
 		public static void EndEvent(string id, string type)
 		{
-			Instance.EndEvent(id, type);
+			Instance?.EndEvent(id, type);
 		}
 
 #if !FRAMELINE_ENABLE
@@ -68,7 +67,7 @@ namespace Tekly.Webster
 #endif
 		public static void Clear()
 		{
-			Instance.Clear();
+			Instance?.Clear();
 		}
 
 #if !FRAMELINE_ENABLE
@@ -102,7 +101,7 @@ namespace Tekly.Webster
 #endif
 		public static void ClearAfter(double time)
 		{
-			Instance.ClearAfter(time);
+			Instance?.ClearAfter(time);
 		}
 
 		public static void Stop()

--- a/Packages/ca.tekly.webster/Webster/Utility/WebsterMenus.cs
+++ b/Packages/ca.tekly.webster/Webster/Utility/WebsterMenus.cs
@@ -1,4 +1,4 @@
-//=============================================================================	
+//=============================================================================
 // Copyright Matthew King. All rights reserved.
 //=============================================================================
 
@@ -61,7 +61,7 @@ namespace Tekly.Webster.Utility
 			DisableDefine(WEBSTER_ENABLE_EDITOR);
 		}
 #endif
-		
+
 #if !WEBSTER_ENABLE_EDIT_MODE
 		[MenuItem("Tools/Tekly/Webster/Enable Webster Edit Mode", priority = 101)]
 		public static void EnableWebsterEditMode()
@@ -72,7 +72,7 @@ namespace Tekly.Webster.Utility
 
 #if WEBSTER_ENABLE_EDIT_MODE
 		[MenuItem("Tools/Tekly/Webster/Disable Webster Edit Mode", priority = 101)]
-		public static void DisableWebsterEditor()
+		public static void DisableWebsterEditMode()
 		{
 			DisableDefine(WEBSTER_ENABLE_EDIT_MODE);
 		}


### PR DESCRIPTION
 - Duplicate method names when Webster Edit Mode and Webster Editor are enabled at the same time
 - NREs when importing Excel sheets while Webster Edit Mode is disabled