### PR TITLE
Fix for softlock when trying to open a build directory that doesn't exist

### DIFF
--- a/Packages/ca.tekly.basicbuilder/Editor/BasicBuildWindow.cs
+++ b/Packages/ca.tekly.basicbuilder/Editor/BasicBuildWindow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using Tekly.Common.Git;
 using Tekly.Common.Gui;
 using UnityEditor;
@@ -165,6 +166,10 @@ namespace Tekly.BasicBuilder
                 using (EditorGuiExt.Horizontal()) {
                     var buildDirectory = BasicBuilder.GetBuildDirectory(EditorUserBuildSettings.activeBuildTarget);
                     if (EditorGUILayout.LinkButton(buildDirectory)) {
+                        if (!Directory.Exists(buildDirectory)) {
+                            Directory.CreateDirectory(buildDirectory);
+                        }
+
                         EditorUtility.RevealInFinder(buildDirectory);
                     }
 


### PR DESCRIPTION
For me, clicking on the build directory folder was causing a soft-lock while it tried repeatedly to open a folder that did not exist. This pull request attempts to create the directory first (if needed) which solved the soft-lock for me.